### PR TITLE
Revert "Update ibm_catalog.json - remove dependencies section"

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -317,6 +317,17 @@
                   "install_type": "extension",
                   "working_directory": "solutions/agents",
                   "compliance": {},
+                  "dependencies": [
+                        {
+                          "flavors": [
+                            "quickstart",
+                            "standard"
+                          ],
+                          "id": "95fccffc-ae3b-42df-b6d9-80be5914d852-global",
+                          "name": "deploy-arch-ibm-slz-ocp",
+                          "version": ">=v3.0.0"
+                        }
+                  ],
                   "configuration": [
                       {
                         "key": "ibmcloud_api_key"


### PR DESCRIPTION
Reverts terraform-ibm-modules/terraform-ibm-scc-da#141

so it seems I can’t mark a version as ready if its an extension type with adding a dependencies section:
![image](https://github.com/terraform-ibm-modules/terraform-ibm-scc-da/assets/29608224/60bf3cb9-0925-4727-987d-631e39e039d5)
