### PR TITLE
fix(deps): bump IBM terraform provider to 1.69.0 to pickup fix for SCC profile attachement creation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-10T06:39:44Z",
+  "generated_at": "2023-12-11T06:39:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/solutions/agents/version.tf
+++ b/solutions/agents/version.tf
@@ -5,7 +5,7 @@ terraform {
     # Lock DA into an exact provider version - renovate automation will keep it updated
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.68.1"
+      version = "1.69.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/solutions/instances/README.md
+++ b/solutions/instances/README.md
@@ -18,7 +18,7 @@ This solution supports provisioning and configuring the following infrastructure
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.68.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.69.0 |
 
 ### Modules
 
@@ -35,12 +35,12 @@ This solution supports provisioning and configuring the following infrastructure
 
 | Name | Type |
 |------|------|
-| [ibm_en_subscription_email.email_subscription](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.68.1/docs/resources/en_subscription_email) | resource |
-| [ibm_en_topic.en_topic](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.68.1/docs/resources/en_topic) | resource |
-| [ibm_en_destinations.en_destinations](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.68.1/docs/data-sources/en_destinations) | data source |
-| [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.68.1/docs/data-sources/iam_account_settings) | data source |
-| [ibm_resource_group.group](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.68.1/docs/data-sources/resource_group) | data source |
-| [ibm_resource_instance.scc_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.68.1/docs/data-sources/resource_instance) | data source |
+| [ibm_en_subscription_email.email_subscription](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/resources/en_subscription_email) | resource |
+| [ibm_en_topic.en_topic](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/resources/en_topic) | resource |
+| [ibm_en_destinations.en_destinations](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/en_destinations) | data source |
+| [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/iam_account_settings) | data source |
+| [ibm_resource_group.group](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/resource_group) | data source |
+| [ibm_resource_instance.scc_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/resource_instance) | data source |
 
 ### Inputs
 

--- a/solutions/instances/version.tf
+++ b/solutions/instances/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.68.1"
+      version = "1.69.0"
     }
   }
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -181,8 +181,6 @@ func TestRunUpgradeInstances(t *testing.T) {
 		"existing_kms_instance_crn":           permanentResources["hpcs_south_crn"],
 		"kms_endpoint_type":                   "public",
 		"management_endpoint_type_for_bucket": "public",
-		// Temp workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5586
-		"profile_attachments": []string{"SOC 2"},
 	}
 
 	output, err := options.RunTestUpgrade()
@@ -251,8 +249,6 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"existing_cos_instance_crn":           terraform.Output(t, existingTerraformOptions, "cos_crn"),
 				"management_endpoint_type_for_bucket": "public",
 				"existing_en_crn":                     terraform.Output(t, existingTerraformOptions, "en_crn"),
-				// Temp workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5586
-				"profile_attachments": []string{"SOC 2"},
 			},
 		})
 
@@ -279,8 +275,6 @@ func TestRunExistingResourcesInstances(t *testing.T) {
 				"kms_endpoint_type":                   "public",
 				"existing_cos_instance_crn":           terraform.Output(t, existingTerraformOptions, "cos_crn"),
 				"management_endpoint_type_for_bucket": "public",
-				// Temp workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5586
-				"profile_attachments": []string{"SOC 2"},
 			},
 		})
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -161,8 +161,6 @@ func TestInstancesInSchematics(t *testing.T) {
 		{Name: "scc_workload_protection_access_tags", Value: permanentResources["accessTags"], DataType: "list(string)"},
 		{Name: "cos_instance_access_tags", Value: permanentResources["accessTags"], DataType: "list(string)"},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		// Temp workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5586
-		{Name: "profile_attachments", Value: []string{"SOC 2"}, DataType: "list(string)"},
 	}
 
 	err := options.RunSchematicTest()


### PR DESCRIPTION
### Description

bump IBM terraform provider to 1.69.0 to pickup fix for SCC profile attachement creation: https://github.com/terraform-ibm-modules/terraform-ibm-scc-da/issues/177

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
