### PR TITLE
fix: add sleep to scc

### DIFF
--- a/solutions/instances/README.md
+++ b/solutions/instances/README.md
@@ -19,7 +19,7 @@ This solution supports provisioning and configuring the following infrastructure
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.69.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | 0.12.0 |
 
 ### Modules
 
@@ -38,7 +38,7 @@ This solution supports provisioning and configuring the following infrastructure
 |------|------|
 | [ibm_en_subscription_email.email_subscription](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/resources/en_subscription_email) | resource |
 | [ibm_en_topic.en_topic](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/resources/en_topic) | resource |
-| [time_sleep.wait_for_scc](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [time_sleep.wait_for_scc](https://registry.terraform.io/providers/hashicorp/time/0.12.0/docs/resources/sleep) | resource |
 | [ibm_en_destinations.en_destinations](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/en_destinations) | data source |
 | [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/iam_account_settings) | data source |
 | [ibm_resource_group.group](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/resource_group) | data source |

--- a/solutions/instances/README.md
+++ b/solutions/instances/README.md
@@ -19,6 +19,7 @@ This solution supports provisioning and configuring the following infrastructure
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.69.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
 
 ### Modules
 
@@ -37,6 +38,7 @@ This solution supports provisioning and configuring the following infrastructure
 |------|------|
 | [ibm_en_subscription_email.email_subscription](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/resources/en_subscription_email) | resource |
 | [ibm_en_topic.en_topic](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/resources/en_topic) | resource |
+| [time_sleep.wait_for_scc](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [ibm_en_destinations.en_destinations](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/en_destinations) | data source |
 | [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/iam_account_settings) | data source |
 | [ibm_resource_group.group](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.69.0/docs/data-sources/resource_group) | data source |

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -266,8 +266,15 @@ data "ibm_en_destinations" "en_destinations" {
   instance_guid = local.existing_en_guid
 }
 
+resource "time_sleep" "wait_for_scc" {
+  depends_on = [module.scc]
+
+  create_duration = "30s"
+}
+
 resource "ibm_en_topic" "en_topic" {
   count         = var.existing_en_crn != null ? 1 : 0
+  depends_on    = [time_sleep.wait_for_scc]
   instance_guid = local.existing_en_guid
   name          = local.en_topic
   description   = "Topic for SCC events routing"

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -266,6 +266,7 @@ data "ibm_en_destinations" "en_destinations" {
   instance_guid = local.existing_en_guid
 }
 
+# workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5533
 resource "time_sleep" "wait_for_scc" {
   depends_on = [module.scc]
 

--- a/solutions/instances/version.tf
+++ b/solutions/instances/version.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = "1.69.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1, < 1.0.0"
+    }
   }
 }

--- a/solutions/instances/version.tf
+++ b/solutions/instances/version.tf
@@ -8,7 +8,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = ">= 0.9.1, < 1.0.0"
+      version = "0.12.0"
     }
   }
 }


### PR DESCRIPTION
### Description

add sleep to scc da code 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

add sleep to avoid timing issue when creating en_topic.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
