### PR TITLE
fix: increase create time sleep

### DIFF
--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -255,7 +255,7 @@ data "ibm_en_destinations" "en_destinations" {
   instance_guid = local.existing_en_guid
 }
 
-# workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5533
+# workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5533.
 resource "time_sleep" "wait_for_scc" {
   depends_on = [module.scc]
 

--- a/solutions/instances/main.tf
+++ b/solutions/instances/main.tf
@@ -259,7 +259,7 @@ data "ibm_en_destinations" "en_destinations" {
 resource "time_sleep" "wait_for_scc" {
   depends_on = [module.scc]
 
-  create_duration = "30s"
+  create_duration = "60s"
 }
 
 resource "ibm_en_topic" "en_topic" {


### PR DESCRIPTION
### Description

increase create time sleep for https://github.com/terraform-ibm-modules/stack-ibm-core-security-services/pull/106

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
