### PR TITLE
fix: mark `existing_kms_instance_crn` required in catalog

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -73,14 +73,14 @@
               "key": "existing_monitoring_crn"
             },
             {
-              "key": "existing_kms_instance_crn"
+              "key": "existing_kms_instance_crn",
+              "required": true
             },
             {
               "key": "existing_scc_instance_crn"
             },
             {
-              "key": "existing_scc_cos_kms_key_crn",
-              "required": true
+              "key": "existing_scc_cos_kms_key_crn"
             },
             {
               "key": "kms_endpoint_type",


### PR DESCRIPTION
### Description

- mark `existing_kms_instance_crn` required in catalog. By passing in a KMS instance, the DA will create a new key by default. Approach is consistent with other DAs

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
